### PR TITLE
Add set operations

### DIFF
--- a/dfply.egg-info/SOURCES.txt
+++ b/dfply.egg-info/SOURCES.txt
@@ -19,3 +19,4 @@ dfply/vendor/six.py
 dfply/vendor/pandas_ply/__init__.py
 dfply/vendor/pandas_ply/symbolic.py
 test/test_base.py
+dfply/set_ops.py

--- a/dfply/__init__.py
+++ b/dfply/__init__.py
@@ -9,3 +9,4 @@ from dfply.reshape import *
 from dfply.transform import *
 from dfply.summarize import *
 from dfply.join import *
+from dfply.set_ops import *

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -1,0 +1,37 @@
+from .base import *
+import warnings
+
+# ==============================================================================
+#
+# SET OPERATIONS
+#
+# These functions treat DataFrames like sets
+#
+# ==============================================================================
+
+
+# ------------------------------------------------------------------------------
+# `union`
+# ------------------------------------------------------------------------------
+
+@pipe
+def union(df, other, index=False, keep='first'):
+    if df.columns.values.tolist() != other.columns.values.tolist():
+        not_in_df = [col for col in other.columns if col not in df.columns]
+        not_in_other = [col for col in df.columns if col not in other.columns]
+        error_string = 'Error: not compatible.'
+        if len(not_in_df):
+            error_string += ' Cols in y but not x: ' + str(not_in_df) + '.'
+        if len(not_in_other):
+            error_string += ' Cols in x but not y: ' + str(not_in_other) + '.'
+        raise ValueError(error_string)
+    stacked = df.append(other)
+    if index:
+        stacked_reset_indexes = stacked.reset_index()
+        index_cols = [col for col in stacked_reset_indexes.columns if col not in df.columns]
+        index_name = df.index.names
+        return_df = stacked_reset_indexes.drop_duplicates(keep=keep).set_index(index_cols)
+        return_df.index.names = index_name
+        return return_df
+    else:
+        return stacked.drop_duplicates(keep=keep)

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -74,3 +74,32 @@ def intersect(df, other, index=False, keep='first'):
                              right_on=df.columns.values.tolist())
         return_df = return_df.drop_duplicates(keep=keep)
         return return_df
+
+
+@pipe
+def set_diff(df, other, index=False, keep='first'):
+    validate_set_ops(df, other)
+    if index:
+        df_reset_index = df.reset_index()
+        other_reset_index = other.reset_index()
+        index_cols = [col for col in df_reset_index.columns if col not in df.columns]
+        df_index_names = df.index.names
+        return_df = (pd.merge(df_reset_index, other_reset_index,
+                              how='left',
+                              left_on=df_reset_index.columns.values.tolist(),
+                              right_on=other_reset_index.columns.values.tolist(),
+                              indicator=True)
+                     .set_index(index_cols))
+        return_df = return_df[return_df._merge == 'left_only']
+        return_df.index.names = df_index_names
+        return_df = return_df.drop_duplicates(keep=keep)[df.columns]
+        return return_df
+    else:
+        return_df = pd.merge(df, other,
+                             how='left',
+                             left_on=df.columns.values.tolist(),
+                             right_on=df.columns.values.tolist(),
+                             indicator=True)
+        return_df = return_df[return_df._merge == 'left_only']
+        return_df = return_df.drop_duplicates(keep=keep)[df.columns]
+        return return_df

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -1,5 +1,6 @@
 from .base import *
 import warnings
+import pandas as pd
 
 # ==============================================================================
 #
@@ -14,7 +15,7 @@ import warnings
 # `union`
 # ------------------------------------------------------------------------------
 
-def validate(df, other):
+def validate_set_ops(df, other):
     if df.columns.values.tolist() != other.columns.values.tolist():
         not_in_df = [col for col in other.columns if col not in df.columns]
         not_in_other = [col for col in df.columns if col not in other.columns]
@@ -24,13 +25,17 @@ def validate(df, other):
         if len(not_in_other):
             error_string += ' Cols in x but not y: ' + str(not_in_other) + '.'
         raise ValueError(error_string)
+    if len(df.index.names) != len(other.index.names):
+        raise ValueError('Index dimension mismatch')
+    if df.index.names != other.index.names:
+        raise ValueError('Index mismatch')
     else:
         return
 
 
 @pipe
 def union(df, other, index=False, keep='first'):
-    validate(df, other)
+    validate_set_ops(df, other)
     stacked = df.append(other)
     if index:
         stacked_reset_indexes = stacked.reset_index()

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -11,10 +11,6 @@ import pandas as pd
 # ==============================================================================
 
 
-# ------------------------------------------------------------------------------
-# `union`
-# ------------------------------------------------------------------------------
-
 def validate_set_ops(df, other):
     # ensure that dataframes are valid for set operations:
     #   columns must be the same name in the same order
@@ -35,6 +31,9 @@ def validate_set_ops(df, other):
     else:
         return
 
+# ------------------------------------------------------------------------------
+# `union`
+# ------------------------------------------------------------------------------
 
 @pipe
 def union(df, other, index=False, keep='first'):
@@ -49,6 +48,10 @@ def union(df, other, index=False, keep='first'):
         return return_df
     else:
         return stacked.drop_duplicates(keep=keep)
+
+# ------------------------------------------------------------------------------
+# `intersect`
+# ------------------------------------------------------------------------------
 
 
 @pipe
@@ -74,6 +77,10 @@ def intersect(df, other, index=False, keep='first'):
                              right_on=df.columns.values.tolist())
         return_df = return_df.drop_duplicates(keep=keep)
         return return_df
+
+# ------------------------------------------------------------------------------
+# `set_diff`
+# ------------------------------------------------------------------------------
 
 
 @pipe

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -14,8 +14,7 @@ import warnings
 # `union`
 # ------------------------------------------------------------------------------
 
-@pipe
-def union(df, other, index=False, keep='first'):
+def validate(df, other):
     if df.columns.values.tolist() != other.columns.values.tolist():
         not_in_df = [col for col in other.columns if col not in df.columns]
         not_in_other = [col for col in df.columns if col not in other.columns]
@@ -25,6 +24,13 @@ def union(df, other, index=False, keep='first'):
         if len(not_in_other):
             error_string += ' Cols in x but not y: ' + str(not_in_other) + '.'
         raise ValueError(error_string)
+    else:
+        return
+
+
+@pipe
+def union(df, other, index=False, keep='first'):
+    validate(df, other)
     stacked = df.append(other)
     if index:
         stacked_reset_indexes = stacked.reset_index()

--- a/dfply/set_ops.py
+++ b/dfply/set_ops.py
@@ -16,6 +16,9 @@ import pandas as pd
 # ------------------------------------------------------------------------------
 
 def validate_set_ops(df, other):
+    # ensure that dataframes are valid for set operations:
+    #   columns must be the same name in the same order
+    #   indexes must be of the same dimension with the same names
     if df.columns.values.tolist() != other.columns.values.tolist():
         not_in_df = [col for col in other.columns if col not in df.columns]
         not_in_other = [col for col in df.columns if col not in other.columns]
@@ -46,3 +49,28 @@ def union(df, other, index=False, keep='first'):
         return return_df
     else:
         return stacked.drop_duplicates(keep=keep)
+
+
+@pipe
+def intersect(df, other, index=False, keep='first'):
+    validate_set_ops(df, other)
+    if index:
+        df_reset_index = df.reset_index()
+        other_reset_index = other.reset_index()
+        index_cols = [col for col in df_reset_index.columns if col not in df.columns]
+        df_index_names = df.index.names
+        return_df = (pd.merge(df_reset_index, other_reset_index,
+                              how='inner',
+                              left_on=df_reset_index.columns.values.tolist(),
+                              right_on=df_reset_index.columns.values.tolist())
+                     .set_index(index_cols))
+        return_df.index.names = df_index_names
+        return_df = return_df.drop_duplicates(keep=keep)
+        return return_df
+    else:
+        return_df = pd.merge(df, other,
+                             how='inner',
+                             left_on=df.columns.values.tolist(),
+                             right_on=df.columns.values.tolist())
+        return_df = return_df.drop_duplicates(keep=keep)
+        return return_df

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -357,6 +357,14 @@ def dfB(scope='module'):
     })
     return b
 
+@pytest.fixture
+def dfC(scope='module'):
+    c = pd.DataFrame({
+        'x1':['B','C','D'],
+        'x2':[2,3,4]
+    })
+    return c
+
 
 def test_inner_join(dfA, dfB):
     ab = pd.DataFrame({
@@ -421,3 +429,33 @@ def test_anti_join(dfA, dfB):
 
     c = dfA >> anti_join(dfB, by='x1')
     assert c.equals(ab)
+
+
+def test_union(dfA, dfC):
+    ac = pd.DataFrame({
+        'x1': ['A', 'B', 'C', 'D'],
+        'x2': [1, 2, 3, 4]
+    }, index=[0, 1, 2, 2])
+
+    d = dfA >> union(dfC)
+    assert d.equals(ac)
+
+
+def test_intersect(dfA, dfC):
+    ac = pd.DataFrame({
+        'x1': ['B', 'C'],
+        'x2': [2, 3]
+    })
+
+    d = dfA >> intersect(dfC)
+    assert d.equals(ac)
+
+
+def test_set_diff(dfA, dfC):
+    ac = pd.DataFrame({
+        'x1': ['A'],
+        'x2': [1]
+    })
+
+    d = dfA >> set_diff(dfC)
+    assert d.equals(ac)


### PR DESCRIPTION
This branch adds dplyr set operations (union, intersect, set_diff).
The set operations treat dataframes like sets, with rows like elements, so the end product will be unique elements (rows). This is in line with the usual use of these operations.

Each operation has the following keywords: `index` and `keep`. R and pandas are pretty different when it comes to indexes, with them being largely invisible in R but upfront and crucial in pandas, so a bit of work went into both preserving and handling indexes (a large portion of the code is dedicated just to this). When `index` is `false` (default), they are ignored, but if `index` is `true`, then they essentially act as another column when it comes to determining uniqueness
And relating to this is the `keep` keyword that says, in the case of duplicates, which observation should be kept. Default is 'first', and since this is essentially a pandas wrapper, the other options are 'last' and `false`, which is to drop all duplicates (wouldn't be useful here).

There may be some operations that could be more performant (e.g. dropping duplicates before the operations as well as after to reduce additional duplicates), but there is some cost associated with that as well), but I opted for simpler code, for at least the first go-around.