### PR TITLE
Summary functions

### DIFF
--- a/dfply.egg-info/SOURCES.txt
+++ b/dfply.egg-info/SOURCES.txt
@@ -12,6 +12,7 @@ dfply/select.py
 dfply/set_ops.py
 dfply/subset.py
 dfply/summarize.py
+dfply/summary_functions.py
 dfply/transform.py
 dfply.egg-info/PKG-INFO
 dfply.egg-info/SOURCES.txt

--- a/dfply.egg-info/SOURCES.txt
+++ b/dfply.egg-info/SOURCES.txt
@@ -26,4 +26,5 @@ test/test_reshape.py
 test/test_select.py
 test/test_subset.py
 test/test_summarize.py
+test/test_summary_functions.py
 test/test_transform.py

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -9,3 +9,8 @@ def mean(series):
 def first(series):
     first_s = series.iloc[0]
     return first_s
+
+
+def last(series):
+    last_s = series.iloc[series.size - 1]
+    return last_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -24,3 +24,8 @@ def n(series):
 def n_distinct(series):
     n_distinct_s = series.unique().size
     return n_distinct_s
+
+
+def IQR(series):
+    iqr_s = series.quantile(.75) - series.quantile(.25)
+    return iqr_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -14,3 +14,8 @@ def first(series):
 def last(series):
     last_s = series.iloc[series.size - 1]
     return last_s
+
+
+def n(series):
+    n_s = series.size
+    return n_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -34,3 +34,8 @@ def IQR(series):
 def min(series):
     min_s = series.min()
     return min_s
+
+
+def max(series):
+    max_s = series.max()
+    return max_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -44,3 +44,8 @@ def max(series):
 def median(series):
     median_s = series.median()
     return median_s
+
+
+def var(series):
+    var_s = series.var()
+    return var_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -19,3 +19,8 @@ def last(series):
 def n(series):
     n_s = series.size
     return n_s
+
+
+def n_distinct(series):
+    n_distinct_s = series.unique().size
+    return n_distinct_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -1,0 +1,6 @@
+from .base import *
+
+
+def mean(series):
+    mean_s = series.mean()
+    return mean_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -29,3 +29,8 @@ def n_distinct(series):
 def IQR(series):
     iqr_s = series.quantile(.75) - series.quantile(.25)
     return iqr_s
+
+
+def min(series):
+    min_s = series.min()
+    return min_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -49,3 +49,8 @@ def median(series):
 def var(series):
     var_s = series.var()
     return var_s
+
+
+def sd(series):
+    sd_s = series.std()
+    return sd_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -39,3 +39,8 @@ def min(series):
 def max(series):
     max_s = series.max()
     return max_s
+
+
+def median(series):
+    median_s = series.median()
+    return median_s

--- a/dfply/summary_functions.py
+++ b/dfply/summary_functions.py
@@ -4,3 +4,8 @@ from .base import *
 def mean(series):
     mean_s = series.mean()
     return mean_s
+
+
+def first(series):
+    first_s = series.iloc[0]
+    return first_s

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -27,3 +27,47 @@ def test_mean():
     t = df >> groupby(X.cut) >> mutate(m=mean(X.x))
     df_truth['m'] = pd.Series([3.950, 4.045, 4.195, 4.045, 4.195])
     assert t.equals(df_truth)
+
+
+def test_first():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(f=first(X.x))
+    df_truth = pd.DataFrame({'f': [3.95]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(m=mean(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'm': [4.195, 3.950, 4.045]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(m=mean(X.x))
+    df_truth = df.copy()
+    df_truth['m'] = df_truth.x.mean()
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(m=mean(X.x))
+    df_truth['m'] = pd.Series([3.950, 4.045, 4.195, 4.045, 4.195])
+    assert t.equals(df_truth)
+
+
+def test_first():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(f=first(X.x))
+    df_truth = pd.DataFrame({'f': [3.95]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(f=first(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'f': [4.05, 3.95, 3.89]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(f=first(X.x))
+    df_truth = df.copy()
+    df_truth['f'] = df_truth.x.iloc[0]
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(f=first(X.x))
+    df_truth['f'] = pd.Series([3.95, 3.89, 4.05, 3.89, 4.05])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -1,0 +1,29 @@
+import pytest
+
+from dfply import *
+
+
+##==============================================================================
+## transform summary functions
+##==============================================================================
+
+def test_mean():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(m=mean(X.x))
+    df_truth = pd.DataFrame({'m': [4.086]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(m=mean(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'm': [4.195, 3.950, 4.045]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(m=mean(X.x))
+    df_truth = df.copy()
+    df_truth['m'] = df_truth.x.mean()
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(m=mean(X.x))
+    df_truth['m'] = pd.Series([3.950, 4.045, 4.195, 4.045, 4.195])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -138,3 +138,27 @@ def test_n_distinct():
     t = df >> groupby(X.col_1) >> mutate(n=n_distinct(X.col_2))
     df_truth['n'] = pd.Series([1, 1, 1, 2, 2, 2, 2, 2])
     assert t.equals(df_truth)
+
+
+def test_IQR():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(i=IQR(X.x))
+    df_truth = pd.DataFrame({'i': [.25]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(i=IQR(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'i': [0.145, 0.000, 0.155]})
+    test_vector = t.i - df_truth.i
+    assert all(test_vector < 0.000000001)
+    # straight mutate
+    t = df >> mutate(i=IQR(X.x))
+    df_truth = df.copy()
+    df_truth['i'] = 0.25
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(i=IQR(X.x))
+    df_truth['i'] = pd.Series([0.000, 0.155, 0.145, 0.155, 0.145])
+    test_vector = t.i - df_truth.i
+    assert all(test_vector < 0.000000001)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -162,3 +162,25 @@ def test_IQR():
     df_truth['i'] = pd.Series([0.000, 0.155, 0.145, 0.155, 0.145])
     test_vector = abs(t.i - df_truth.i)
     assert all(test_vector < 0.000000001)
+
+
+def test_min():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(m=min(X.x))
+    df_truth = pd.DataFrame({'m': [3.89]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(m=min(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'm': [4.05, 3.95, 3.89]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(m=min(X.x))
+    df_truth = df.copy()
+    df_truth['m'] = 3.89
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(m=min(X.x))
+    df_truth['m'] = pd.Series([3.95, 3.89, 4.05, 3.89, 4.05])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -184,3 +184,25 @@ def test_min():
     t = df >> groupby(X.cut) >> mutate(m=min(X.x))
     df_truth['m'] = pd.Series([3.95, 3.89, 4.05, 3.89, 4.05])
     assert t.equals(df_truth)
+
+
+def test_max():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(m=max(X.x))
+    df_truth = pd.DataFrame({'m': [4.34]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(m=max(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'm': [4.34, 3.95, 4.20]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(m=max(X.x))
+    df_truth = df.copy()
+    df_truth['m'] = 4.34
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(m=max(X.x))
+    df_truth['m'] = pd.Series([3.95, 4.20, 4.34, 4.20, 4.34])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -36,28 +36,6 @@ def test_first():
     df_truth = pd.DataFrame({'f': [3.95]})
     assert t.equals(df_truth)
     # grouped summarize
-    t = df >> groupby(X.cut) >> summarize(m=mean(X.x))
-    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
-                             'm': [4.195, 3.950, 4.045]})
-    assert t.equals(df_truth)
-    # straight mutate
-    t = df >> mutate(m=mean(X.x))
-    df_truth = df.copy()
-    df_truth['m'] = df_truth.x.mean()
-    assert t.equals(df_truth)
-    # grouped mutate
-    t = df >> groupby(X.cut) >> mutate(m=mean(X.x))
-    df_truth['m'] = pd.Series([3.950, 4.045, 4.195, 4.045, 4.195])
-    assert t.equals(df_truth)
-
-
-def test_first():
-    df = diamonds >> select(X.cut, X.x) >> head(5)
-    # straight summarize
-    t = df >> summarize(f=first(X.x))
-    df_truth = pd.DataFrame({'f': [3.95]})
-    assert t.equals(df_truth)
-    # grouped summarize
     t = df >> groupby(X.cut) >> summarize(f=first(X.x))
     df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
                              'f': [4.05, 3.95, 3.89]})
@@ -82,7 +60,7 @@ def test_last():
     # grouped summarize
     t = df >> groupby(X.cut) >> summarize(l=last(X.x))
     df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
-                             'f': [4.34, 3.95, 4.20]})
+                             'l': [4.34, 3.95, 4.20]})
     assert t.equals(df_truth)
     # straight mutate
     t = df >> mutate(l=last(X.x))
@@ -271,4 +249,39 @@ def test_var():
     t = df >> groupby(X.cut) >> summarize(v=var(X.x))
     df_truth = pd.DataFrame({'cut': ['Fair', 'Good', 'Ideal', 'Premium', 'Very Good'],
                              'v': [np.nan, np.nan, np.nan, np.nan, np.nan]})
+    assert t.equals(df_truth)
+
+
+def test_sd():
+    df = diamonds >> groupby(X.cut) >> head(3) >> select(X.cut, X.x)
+    # straight summarize
+    t = df >> summarize(s=sd(X.x))
+    df_truth = pd.DataFrame({'s': [0.829091]})
+    test_vector = abs(t.s - df_truth.s)
+    assert all(test_vector < .00001)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(s=sd(X.x))
+    df_truth = pd.DataFrame({'cut': ['Fair', 'Good', 'Ideal', 'Premium', 'Very Good'],
+                             's': [1.440417, 0.148436, 0.236925, 0.181934, 0.072342]})
+    test_vector = abs(t.s - df_truth.s)
+    assert all(test_vector < .00001)
+    # straight mutate
+    t = df >> mutate(s=sd(X.x))
+    df_truth = df.copy()
+    df_truth['s'] = 0.829091
+    test_vector = abs(t.s - df_truth.s)
+    assert all(test_vector < .00001)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(s=sd(X.x))
+    df_truth['s'] = pd.Series([1.440417, 1.440417, 1.440417, 0.148436, 0.148436, 0.148436,
+                               0.236925, 0.236925, 0.236925, 0.181934, 0.181934, 0.181934,
+                               0.072342, 0.072342, 0.072342],
+                              index=t.index)
+    test_vector = abs(t.s - df_truth.s)
+    assert all(test_vector < .00001)
+    # test with single value (var undefined)
+    df = diamonds >> groupby(X.cut) >> head(1) >> select(X.cut, X.x)
+    t = df >> groupby(X.cut) >> summarize(s=sd(X.x))
+    df_truth = pd.DataFrame({'cut': ['Fair', 'Good', 'Ideal', 'Premium', 'Very Good'],
+                             's': [np.nan, np.nan, np.nan, np.nan, np.nan]})
     assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -71,3 +71,25 @@ def test_first():
     t = df >> groupby(X.cut) >> mutate(f=first(X.x))
     df_truth['f'] = pd.Series([3.95, 3.89, 4.05, 3.89, 4.05])
     assert t.equals(df_truth)
+
+
+def test_last():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(l=last(X.x))
+    df_truth = pd.DataFrame({'l': [4.34]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(l=last(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'f': [4.34, 3.95, 4.20]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(l=last(X.x))
+    df_truth = df.copy()
+    df_truth['l'] = df_truth.x.iloc[4]
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(l=last(X.x))
+    df_truth['l'] = pd.Series([3.95, 4.20, 4.34, 4.20, 4.34])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -115,3 +115,26 @@ def test_n():
     t = df >> groupby(X.cut) >> mutate(n=n(X.x))
     df_truth['n'] = pd.Series([1, 2, 2, 2, 2, 2])
     assert t.equals(df_truth)
+
+
+def test_n_distinct():
+    df = pd.DataFrame({'col_1': ['a', 'a', 'a', 'b', 'b', 'b', 'c', 'c'],
+                       'col_2': [1, 1, 1, 2, 3, 3, 4, 5]})
+    # straight summarize
+    t = df >> summarize(n=n_distinct(X.col_2))
+    df_truth = pd.DataFrame({'n': [5]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.col_1) >> summarize(n=n_distinct(X.col_2))
+    df_truth = pd.DataFrame({'col_1': ['a', 'b', 'c'],
+                             'n': [1, 2, 2]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(n=n_distinct(X.col_2))
+    df_truth = df.copy()
+    df_truth['n'] = 5
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.col_1) >> mutate(n=n_distinct(X.col_2))
+    df_truth['n'] = pd.Series([1, 1, 1, 2, 2, 2, 2, 2])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -93,3 +93,25 @@ def test_last():
     t = df >> groupby(X.cut) >> mutate(l=last(X.x))
     df_truth['l'] = pd.Series([3.95, 4.20, 4.34, 4.20, 4.34])
     assert t.equals(df_truth)
+
+
+def test_n():
+    df = diamonds >> select(X.cut, X.x) >> head(5)
+    # straight summarize
+    t = df >> summarize(n=n(X.x))
+    df_truth = pd.DataFrame({'n': [5]})
+    assert t.equals(df_truth)
+    # grouped summarize
+    t = df >> groupby(X.cut) >> summarize(n=n(X.x))
+    df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
+                             'n': [2, 1, 2]})
+    assert t.equals(df_truth)
+    # straight mutate
+    t = df >> mutate(n=n(X.x))
+    df_truth = df.copy()
+    df_truth['n'] = 5
+    assert t.equals(df_truth)
+    # grouped mutate
+    t = df >> groupby(X.cut) >> mutate(n=n(X.x))
+    df_truth['n'] = pd.Series([1, 2, 2, 2, 2, 2])
+    assert t.equals(df_truth)

--- a/test/test_summary_functions.py
+++ b/test/test_summary_functions.py
@@ -150,7 +150,7 @@ def test_IQR():
     t = df >> groupby(X.cut) >> summarize(i=IQR(X.x))
     df_truth = pd.DataFrame({'cut': ['Good', 'Ideal', 'Premium'],
                              'i': [0.145, 0.000, 0.155]})
-    test_vector = t.i - df_truth.i
+    test_vector = abs(t.i - df_truth.i)
     assert all(test_vector < 0.000000001)
     # straight mutate
     t = df >> mutate(i=IQR(X.x))
@@ -160,5 +160,5 @@ def test_IQR():
     # grouped mutate
     t = df >> groupby(X.cut) >> mutate(i=IQR(X.x))
     df_truth['i'] = pd.Series([0.000, 0.155, 0.145, 0.155, 0.145])
-    test_vector = t.i - df_truth.i
+    test_vector = abs(t.i - df_truth.i)
     assert all(test_vector < 0.000000001)


### PR DESCRIPTION
This PR adds most of the summary functions from [data wrangling cheatsheet](https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf). They work with summarize and mutate. Since it's more or less copying the `dplyr` syntax, it uses R's more functional style as opposed to python's method style (e.g. `mean(X.x)` instead of `X.x.mean()`).

Two big notes: 
1: You may want to cherrypick this PR, since it overrides `min` and `max`. Should they be renamed to something `dfply` specific?

2: I haven't quite figured out `nth`. It's easy enough if there is an nth element, but if there's not an nth element, it should return NA. However, `dfply` doesn't want to play well with try/except, so accessing a non-existent element raises an `IndexError`. Not sure how to get around this until I dive a little more deeply into the delayed evaluation aspect.

Hopefully I got the includes right this time.