### PR TITLE
Add top n

### DIFF
--- a/dfply/subset.py
+++ b/dfply/subset.py
@@ -54,3 +54,17 @@ def mask(df, *args):
             raise Exception("Arguments must be boolean.")
         mask = mask & arg
     return df[mask.values]
+
+
+@dfpipe
+def top_n(df, *args, n=None, ascending=True):
+    if not n:
+        raise ValueError('n must be specified')
+    if not args:
+        col = df.columns[-1]
+    else:
+        col = args[0]._name
+    index = df[[col]].copy()
+    index['ranks'] = index[col].rank(ascending=ascending)
+    index = index[index['ranks'] >= index['ranks'].nlargest(n).min()]
+    return df.reindex(index.index)

--- a/dfply/subset.py
+++ b/dfply/subset.py
@@ -57,13 +57,13 @@ def mask(df, *args):
 
 
 @dfpipe
-def top_n(df, *args, n=None, ascending=True):
+def top_n(df, n=None, ascending=True, col=None):
     if not n:
         raise ValueError('n must be specified')
-    if not args:
+    if not isinstance(col, pd.Series):
         col = df.columns[-1]
     else:
-        col = args[0]._name
+        col = col._name
     index = df[[col]].copy()
     index['ranks'] = index[col].rank(ascending=ascending)
     index = index[index['ranks'] >= index['ranks'].nlargest(n).min()]

--- a/test/test_subset.py
+++ b/test/test_subset.py
@@ -80,3 +80,19 @@ def test_mask():
     df_mask = df_mask & (diamonds.table < 55) & (diamonds.price < 500)
     df = diamonds[df_mask]
     assert df.equals(test2)
+
+
+def test_top_n():
+    with pytest.raises(ValueError):
+        diamonds >> top_n()
+    test2 = diamonds >> top_n(n=6)
+    df2 = diamonds.sort_values('z', ascending=False).head(6).sort_index()
+    assert test2.equals(df2)
+    test3 = diamonds >> top_n(X.x, n=5)
+    df3 = diamonds.sort_values('x', ascending=False).head(5).sort_index()
+    assert test3.equals(df3)
+    test4 = diamonds >> top_n(X.cut, n=1)
+    df4 = diamonds[diamonds.cut == 'Very Good']
+    assert test4.equals(df4)
+    test5 = diamonds >> groupby(X.cut) >> top_n(n=2)
+    df5 = diamonds.sort_values('z', ascending=False).groupby('cut').head(2).sort_values('cut')

--- a/test/test_subset.py
+++ b/test/test_subset.py
@@ -95,4 +95,8 @@ def test_top_n():
     df4 = diamonds[diamonds.cut == 'Very Good']
     assert test4.equals(df4)
     test5 = diamonds >> groupby(X.cut) >> top_n(n=2)
-    df5 = diamonds.sort_values('z', ascending=False).groupby('cut').head(2).sort_values('cut')
+    df5 = diamonds.ix[[27415, 27630, 23539, 27517, 27518, 24297, 24328, 24067, 25999, 26444, 48410]]
+    assert test5.equals(df5)
+    test6 = diamonds >> top_n(X.x, ascending=False, n=5)
+    df6 = diamonds.sort_values('x', ascending=True).head(8).sort_index()
+    assert test6.equals(df6)

--- a/test/test_subset.py
+++ b/test/test_subset.py
@@ -88,15 +88,15 @@ def test_top_n():
     test2 = diamonds >> top_n(n=6)
     df2 = diamonds.sort_values('z', ascending=False).head(6).sort_index()
     assert test2.equals(df2)
-    test3 = diamonds >> top_n(X.x, n=5)
+    test3 = diamonds >> top_n(col=X.x, n=5)
     df3 = diamonds.sort_values('x', ascending=False).head(5).sort_index()
     assert test3.equals(df3)
-    test4 = diamonds >> top_n(X.cut, n=1)
+    test4 = diamonds >> top_n(col=X.cut, n=1)
     df4 = diamonds[diamonds.cut == 'Very Good']
     assert test4.equals(df4)
     test5 = diamonds >> groupby(X.cut) >> top_n(n=2)
     df5 = diamonds.ix[[27415, 27630, 23539, 27517, 27518, 24297, 24328, 24067, 25999, 26444, 48410]]
     assert test5.equals(df5)
-    test6 = diamonds >> top_n(X.x, ascending=False, n=5)
+    test6 = diamonds >> top_n(col=X.x, ascending=False, n=5)
     df6 = diamonds.sort_values('x', ascending=True).head(8).sort_index()
     assert test6.equals(df6)


### PR DESCRIPTION
Adds top_n functionality.
eg. `df >> top_n(X.x, n=5 [,ascending=True])`
`n` must be specified; like `dplyr`, if no column is specified, then the last column is used as a default
May return more than n in the case of ties