### PR TITLE
Allow distinct() to take no arguments to apply to whole dataframe

### DIFF
--- a/dfply/subset.py
+++ b/dfply/subset.py
@@ -30,6 +30,8 @@ def sample(df, *args, **kwargs):
 @group_delegation
 @symbolic_reference
 def distinct(df, *args, **kwargs):
+    if not args:
+        return df.drop_duplicates(**kwargs)
     return df.drop_duplicates(list(args), **kwargs)
 
 

--- a/test/test_subset.py
+++ b/test/test_subset.py
@@ -40,6 +40,14 @@ def test_distinct():
     df = diamonds.drop_duplicates(['cut','depth'])
     assert df.equals(d)
 
+    df = diamonds[['carat', 'cut']].drop_duplicates()
+    d = diamonds >> select(X.carat, X.cut) >> distinct()
+    assert df.equals(d)
+
+    df = diamonds[['carat', 'cut']].drop_duplicates(keep='last')
+    d = diamonds >> select(X.carat, X.cut) >> distinct(keep='last')
+    assert df.equals(d)
+
 
 def test_sample():
     random_state = 55


### PR DESCRIPTION
In reference to Allow distinct with no arguments #17 