### PR TITLE
Select if / drop if

### DIFF
--- a/dfply/select.py
+++ b/dfply/select.py
@@ -223,7 +223,7 @@ def select_if(df, fun):
 
     Args:
         fun: a function that will be applied to columns
-    
+
     """
     cols = list()
     for col in df:

--- a/dfply/select.py
+++ b/dfply/select.py
@@ -233,3 +233,22 @@ def select_if(df, fun):
         except:
             pass
     return df[cols]
+
+
+@pipe
+def drop_if(df, fun):
+    """Drops columns where fun(ction) is true
+
+    Args:
+        fun: a function that will be applied to columns
+
+    """
+    cols = list()
+    for col in df:
+        try:
+            if fun(df[col]):
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in df if col not in cols]
+    return df[inverse_cols]

--- a/dfply/select.py
+++ b/dfply/select.py
@@ -215,3 +215,21 @@ def drop_through(df, end_index):
             label, or symbolic pandas series.
     """
     return df.drop(df.columns[:end_index+1], axis=1)
+
+
+@pipe
+def select_if(df, fun):
+    """Selects columns where fun(ction) is true
+
+    Args:
+        fun: a function that will be applied to columns
+    
+    """
+    cols = list()
+    for col in df:
+        try:
+            if fun(df[col]):
+                cols.append(col)
+        except:
+            pass
+    return df[cols]

--- a/test/test_select.py
+++ b/test/test_select.py
@@ -254,5 +254,3 @@ def test_drop_if():
     inverse_cols = [col for col in diamonds if col not in cols]
     df_if = diamonds[inverse_cols]
     assert df_if.equals(diamonds >> drop_if(lambda col: any(col.str.contains('.'))))
-
-test_drop_if()

--- a/test/test_select.py
+++ b/test/test_select.py
@@ -187,3 +187,72 @@ def test_select_if():
             pass
     df_if = diamonds[cols]
     assert df_if.equals(diamonds >> select_if(lambda col: any(col.str.contains('.'))))
+
+
+def test_drop_if():
+    # test 1: returns a dataframe where any column does not have a mean greater than 3
+    # this means numeric columns with mean less than 3, and also any non-numeric column
+    # (since it does not have a mean)
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3:
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in diamonds if col not in cols]
+    df_if = diamonds[inverse_cols]
+    assert df_if.equals(diamonds >> drop_if(lambda col: mean(col) > 3))
+    # test 2: use and
+    # return colums where both conditions are false:
+    # the mean greater than 3, and max < 50
+    # again, this will include non-numeric columns
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3 and max(diamonds[col]) < 50:
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in diamonds if col not in cols]
+    df_if = diamonds[inverse_cols]
+    assert df_if.equals(diamonds >> drop_if(lambda col: mean(col) > 3 and max(col) < 50))
+    # test 3: use or
+    # this will return a dataframe where either of the two conditions are false:
+    # the mean is greater than 3, or the max < 6
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3 or max(diamonds[col]) < 6:
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in diamonds if col not in cols]
+    df_if = diamonds[inverse_cols]
+    assert df_if.equals(diamonds >> drop_if(lambda col: mean(col) > 3 or max(col) < 6))
+    # test 4: string operations - contain a specific string
+    # this will drop any columns if they contain the word 'Ideal'
+    cols = list()
+    for col in diamonds:
+        try:
+            if any(diamonds[col].str.contains('Ideal')):
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in diamonds if col not in cols]
+    df_if = diamonds[inverse_cols]
+    assert df_if.equals(diamonds >> drop_if(lambda col: any(col.str.contains('Ideal'))))
+    # test 5: drop any text columns
+    # uses the special '.' regex symbol to find any text value
+    cols = list()
+    for col in diamonds:
+        try:
+            if any(diamonds[col].str.contains('.')):
+                cols.append(col)
+        except:
+            pass
+    inverse_cols = [col for col in diamonds if col not in cols]
+    df_if = diamonds[inverse_cols]
+    assert df_if.equals(diamonds >> drop_if(lambda col: any(col.str.contains('.'))))
+
+test_drop_if()

--- a/test/test_select.py
+++ b/test/test_select.py
@@ -132,3 +132,58 @@ def drop_through():
     assert df.equals(diamonds >> drop_through('x'))
     assert df.equals(diamonds >> drop_through(X.x))
     assert df.equals(diamonds >> drop_through(7))
+
+
+def test_select_if():
+    # test 1: manually build diamonds subset where columns are numeric and
+    # mean is greater than 3
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3:
+                cols.append(col)
+        except:
+            pass
+    df_if = diamonds[cols]
+    assert df_if.equals(diamonds >> select_if(lambda col: mean(col) > 3))
+    # test 2: use and
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3 and max(diamonds[col]) < 50:
+                cols.append(col)
+        except:
+            pass
+    df_if = diamonds[cols]
+    assert df_if.equals(diamonds >> select_if(lambda col: mean(col) > 3 and max(col) < 50))
+    # test 3: use or
+    cols = list()
+    for col in diamonds:
+        try:
+            if mean(diamonds[col]) > 3 or max(diamonds[col]) < 6:
+                cols.append(col)
+        except:
+            pass
+    df_if = diamonds[cols]
+    assert df_if.equals(diamonds >> select_if(lambda col: mean(col) > 3 or max(col) < 6))
+    # test 4: string operations - contain a specific string
+    cols = list()
+    for col in diamonds:
+        try:
+            if any(diamonds[col].str.contains('Ideal')):
+                cols.append(col)
+        except:
+            pass
+    df_if = diamonds[cols]
+    assert df_if.equals(diamonds >> select_if(lambda col: any(col.str.contains('Ideal'))))
+    # test 5: get any text columns
+    # uses the special '.' regex symbol to find any text value
+    cols = list()
+    for col in diamonds:
+        try:
+            if any(diamonds[col].str.contains('.')):
+                cols.append(col)
+        except:
+            pass
+    df_if = diamonds[cols]
+    assert df_if.equals(diamonds >> select_if(lambda col: any(col.str.contains('.'))))


### PR DESCRIPTION
This PR adds `select_if` and `drop_if` functionality to `dfply`. 
Usage is like:

df >> select_if(lambda col: mean(col) > 3)

returns a dataframe based on df, where each column has a mean > 3. This means that only numeric columns will be returned, since other columns won't have a mean. Any valid lambda function should be sufficient, so you can use `and` or `or`, e.g.

df >> select_if(lambda col: mean(col) > 3 or 'Ideal' in col.values)

Will return a dataframe based on df, where each column either has a mean > 3 or contains the word 'Ideal' somewhere in there.