### PR TITLE
Add mutate_if() function and test cases

### DIFF
--- a/dfply/transform.py
+++ b/dfply/transform.py
@@ -70,3 +70,36 @@ def transmute(df, *keep_columns, **kwargs):
         df[key] = value
     columns = [k for k in kwargs.keys()]+list(keep_cols)
     return df.select(lambda x: x in columns, axis=1)
+
+
+@dfpipe
+def mutate_if(df, predicate, fun):
+    """
+    Modifies columns in place if the specified predicate is true.
+
+    Args:
+        df (pandas.DataFrame): data passed in through the pipe.
+        predicate: a function applied to columns that returns a boolean value
+        fun: a function that will be applied to columns where predicate returns True
+
+    Example:
+        diamonds >> mutate_if(lambda col: min(col) < 1 and mean(col) < 4, lambda row: 2 * row) >> head(3)
+
+           carat      cut color clarity  depth  table  price     x     y     z
+        0   0.46    Ideal     E     SI2   61.5   55.0    326  3.95  3.98  4.86
+        1   0.42  Premium     E     SI1   59.8   61.0    326  3.89  3.84  4.62
+        2   0.46     Good     E     VS1   56.9   65.0    327  4.05  4.07  4.62
+
+        (columns 'carat' and 'z', both having a min < 1 and mean < 4, are doubled, while the
+        other rows remain as they were)
+    """
+    cols = list()
+    for col in df:
+        try:
+            if predicate(df[col]):
+                cols.append(col)
+        except:
+            pass
+    df2 = df.copy()
+    df2[cols] = df2[cols].apply(fun)
+    return df2

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -44,3 +44,30 @@ def test_group_transmute():
     df = df[['cut','testcol']]
     d = diamonds >> groupby('cut') >> transmute(testcol=X.x*X.shape[0])
     assert df.equals(d)
+
+
+def test_mutate_if():
+    df = diamonds.copy()
+    for col in df:
+        try:
+            if max(df[col]) < 10:
+                df[col] *= 2
+        except:
+            pass
+    assert df.equals(diamonds >> mutate_if(lambda col: max(col) < 10, lambda row: row * 2))
+    df = diamonds.copy()
+    for col in df:
+        try:
+            if any(df[col].str.contains('.')):
+                df[col] = df[col].str.lower()
+        except:
+            pass
+    assert df.equals(diamonds >> mutate_if(lambda col: any(col.str.contains('.')), lambda row: row.str.lower()))
+    df = diamonds.copy()
+    for col in df:
+        try:
+            if min(df[col]) < 1 and mean(df[col]) < 4:
+                df[col] *= -1
+        except:
+            pass
+    assert df.equals(diamonds >> mutate_if(lambda col: min(col) < 1 and mean(col) < 4, lambda row: -row))


### PR DESCRIPTION
Adds mutate_if() function. This might be a good place to add some helper functions that can represent common use cases that don't appear to be part of pandas, e.g. an 'is_numeric' function, 'is_character', etc.

Line 103 copies the dataframe, because the function calls an inplace operation. I wasn't sure if that was required or not. If not required, it should probably be removed.