### PR TITLE
Add row_number() function and test cases

### DIFF
--- a/dfply/window_functions.py
+++ b/dfply/window_functions.py
@@ -211,6 +211,16 @@ def row_number(series, ascending=True):
 
     Kwargs:
         ascending (bool): whether to rank in ascending order (default is `True`).
+
+    Usage:
+    diamonds >> head() >> mutate(rn=row_number(X.x))
+
+       carat      cut color clarity  depth  table  price     x     y     z   rn
+    0   0.23    Ideal     E     SI2   61.5   55.0    326  3.95  3.98  2.43  2.0
+    1   0.21  Premium     E     SI1   59.8   61.0    326  3.89  3.84  2.31  1.0
+    2   0.23     Good     E     VS1   56.9   65.0    327  4.05  4.07  2.31  3.0
+    3   0.29  Premium     I     VS2   62.4   58.0    334  4.20  4.23  2.63  4.0
+    4   0.31     Good     J     SI2   63.3   58.0    335  4.34  4.35  2.75  5.0
     """
 
     series_rank = series.rank(method='first', ascending=ascending)

--- a/dfply/window_functions.py
+++ b/dfply/window_functions.py
@@ -198,3 +198,20 @@ def percent_rank(series, ascending=True):
         return 0
     percents = (series.rank(method='min', ascending=ascending) - 1) / (series.size - 1)
     return percents
+
+
+@make_symbolic
+def row_number(series, ascending=True):
+    """
+    Returns row number based on column rank
+    Equivalent to `series.rank(method='first', ascending=ascending)`.
+
+    Args:
+        series: column to rank.
+
+    Kwargs:
+        ascending (bool): whether to rank in ascending order (default is `True`).
+    """
+
+    series_rank = series.rank(method='first', ascending=ascending)
+    return series_rank

--- a/test/test_window_functions.py
+++ b/test/test_window_functions.py
@@ -163,3 +163,28 @@ def test_percent_rank():
     assert df_pr.equals(df_truth.assign(pr=[0.0, 0.0, 0.0, 1.0, 1.0]))
     df_pr = df >> mutate(pr=percent_rank(X.x, ascending=False))
     assert df_pr.equals(df_truth.assign(pr=[0.75, 1.0, 0.50, 0.25, 0.00]))
+
+
+def test_row_number():
+    df = diamonds.copy().head(5).sort_values(by='x')
+    df['rn'] = range(1, df.shape[0] + 1)
+    df['rn'] = df['rn'].astype(float)
+    df.sort_index(inplace=True)
+    assert df.equals(diamonds >> head(5) >> mutate(rn=row_number(X.x)))
+    # test 2: row number with desc() option
+    df = diamonds.copy().head(5).sort_values(by='x', ascending=False)
+    df['rn'] = range(1, df.shape[0] + 1)
+    df['rn'] = df['rn'].astype(float)
+    df.sort_index(inplace=True)
+    assert df.equals(diamonds >> head(5) >> mutate(rn=row_number(desc(X.x))))
+    # test 3: row number with ascending keyword
+    df = diamonds.copy().head(5).sort_values(by='x', ascending=False)
+    df['rn'] = range(1, df.shape[0] + 1)
+    df['rn'] = df['rn'].astype(float)
+    df.sort_index(inplace=True)
+    assert df.equals(diamonds >> head(5) >> mutate(rn=row_number(X.x, ascending=False)))
+    # test 4: with a group by
+    df = diamonds.copy().head(5)
+    df['rn'] = [1, 1, 1, 2, 2]
+    df['rn'] = df['rn'].astype(float)
+    assert df.equals(diamonds >> head(5) >> groupby(X.cut) >> mutate(rn=row_number(X.x)))


### PR DESCRIPTION
Provides row number based on specified column (equivalent to rank(method='first')).
Returns a float (should this be changed to an int? If so, then maybe some of the other ranks should be changed to int as well. I believe pandas just returns a float because it's part of the rank family, which can return averages, so non-int values).

Usage

```
diamonds >> head() >> mutate(rn=row_number(X.x))

   carat      cut color clarity  depth  table  price     x     y     z   rn
0   0.23    Ideal     E     SI2   61.5   55.0    326  3.95  3.98  2.43  2.0
1   0.21  Premium     E     SI1   59.8   61.0    326  3.89  3.84  2.31  1.0
2   0.23     Good     E     VS1   56.9   65.0    327  4.05  4.07  2.31  3.0
3   0.29  Premium     I     VS2   62.4   58.0    334  4.20  4.23  2.63  4.0
4   0.31     Good     J     SI2   63.3   58.0    335  4.34  4.35  2.75  5.0

```