### PR TITLE
Feature: add pipe docs

### DIFF
--- a/dfply/base.py
+++ b/dfply/base.py
@@ -35,6 +35,7 @@ class pipe(object):
 
     def __init__(self, function):
         self.function = function
+        self.__doc__ = function.__doc__
 
 
     def __rrshift__(self, other):


### PR DESCRIPTION
This makes the help that you get when you use shift tab for help in jupyter more informative

This should give people the right docstring when typing help(piped_function).

As an example, before, `help(mutate)` produced the docstring for `pipe`. Now it produces the docstring for `mutate`.