### PR TITLE
Don't run `apt-get update`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 - '3.5'
 - '3.6'
 install:
-- sudo apt-get update
 - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 - bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
As no packages are installed from the repositories during the Travis CI build, there is no need to resynchronise the package index files.