### PR TITLE
Also run tests with Python 3.6 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - '2.7'
 - '3.5'
+- '3.6'
 install:
 - sudo apt-get update
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh


### PR DESCRIPTION
Python 3.6 is the current stable release, and also the version that will be installed if a user who has installed Miniconda3 today creates a new Conda environment without explicitly specifying the Python version.