### PR TITLE
Metadata saved after group_by operation

### DIFF
--- a/dfply/base.py
+++ b/dfply/base.py
@@ -306,7 +306,11 @@ class group_delegation(object):
     def _apply(self, df, *args, **kwargs):
         grouped = df.groupby(df._grouped_by)
 
-        df = grouped.apply(self.function, *args, **kwargs)
+        dff = grouped.apply(self.function, *args, **kwargs)
+        # Save all the metadata attributes back into the new data frame
+        for field in df._metadata:
+            setattr(dff, field, getattr(df, field))
+        df = dff
 
         for name in df.index.names[:-1]:
             if name in df:


### PR DESCRIPTION
The goal of this pull request is to allow metadata parameters to be kept while doing group by operations.

It can be used for example when having a plot pipeline, to store information about plot configuration until we show it (with the spirit of ggplot/plotly pipelines in R)

The `_group_by` property could then also be registered as a dataframe metadata, which would simplify the copy of dataframes in dfply.

More about `_metadata` in pandas: https://pandas.pydata.org/pandas-docs/stable/internals.html#define-original-properties
