### PR TITLE
Add ability to pass positional arguments to `summarize()`

### DIFF
--- a/dfply/summarize.py
+++ b/dfply/summarize.py
@@ -2,7 +2,17 @@ from .base import *
 
 
 @dfpipe
-def summarize(df, **kwargs):
+def summarize(df, *args, **kwargs):
+    for e, v in enumerate(args):
+        column_name = "unnamed_arg_{}".format(e)
+        if column_name not in kwargs:
+            kwargs[column_name] = v
+        else:
+            raise KeyError(
+                "Positional argument {} was assigned "
+                "name '{}', which was also supplied as "
+                "a keyword argument.".format(e, column_name)
+            )
     return pd.DataFrame({k: [v] for k, v in kwargs.items()})
 
 

--- a/test/test_summarize.py
+++ b/test/test_summarize.py
@@ -24,6 +24,28 @@ def test_summarize():
                        summarize(price_mean=X.price.mean(), price_std=X.price.std()))
 
 
+def test_summarize_positional_args():
+    with_args = diamonds >> summarize(
+        X.price.mean(),
+        price_std=X.price.std()
+    ) >> rename(
+        price_mean=X.unnamed_arg_0
+    )
+
+    with_kwargs = diamonds >> summarize(
+        price_std=X.price.std(),
+        price_mean=X.price.mean()
+    )
+
+    # Use `sort_index()` to account for
+    # Python versions < 3.6 which do not
+    # reliably conserve dictionary insertion order.
+    pd.testing.assert_frame_equal(
+        with_kwargs.sort_index(axis=1),
+        with_args.sort_index(axis=1)
+    )
+
+
 def test_summarize_each():
     to_match = pd.DataFrame({
         'price_mean':[np.mean(diamonds.price)],

--- a/test/test_summarize.py
+++ b/test/test_summarize.py
@@ -24,7 +24,7 @@ def test_summarize():
                        summarize(price_mean=X.price.mean(), price_std=X.price.std()))
 
 
-def test_summarize_positional_args():
+def test_summarize_with_positional_args():
     with_args = diamonds >> summarize(
         X.price.mean(),
         price_std=X.price.std()


### PR DESCRIPTION
This PR adds the ability to pass positional arguments to `summarize()`.
This is often very handy when scripting and one just wants to quickly see the result.

Example:

```
from dfply import *

diamonds >> summarize(X.price.mean())

#   unnamed_arg_0
# 0    3932.799722
```

In `dplyr`, `summarize()` will use the code as the column name if the user does not provide one.
Apart from being difficult to replicate in Python (i.e., without non-standard evaluation),
it can make for quite cumbersome column names. So instead, here I generate column names
which correspond to the position of the `args`.

I am open to any ideas you may have.
