### PR TITLE
Throw error when grouping by an unknown column (closes #81)

### DIFF
--- a/dfply/base.py
+++ b/dfply/base.py
@@ -325,7 +325,7 @@ class group_delegation(object):
 
     def __call__(self, *args, **kwargs):
         grouped_by = getattr(args[0], '_grouped_by', None)
-        if (grouped_by is None) or not all([g in args[0].columns for g in grouped_by]):
+        if grouped_by is None:
             return self.function(*args, **kwargs)
         else:
             applied = self._apply(args[0], *args[1:], **kwargs)
@@ -343,3 +343,11 @@ def dfpipe(f):
             symbolic_evaluation(f)
         )
     )
+
+
+def assert_known_cols(df, cols):
+    bad_cols = [g for g in cols if g not in df.columns]
+    if bad_cols:
+        raise Exception(
+            'The following columns are unknown: ' + ', '.join(bad_cols)
+        )

--- a/dfply/group.py
+++ b/dfply/group.py
@@ -4,6 +4,7 @@ from .base import *
 @pipe
 @symbolic_evaluation(eval_as_label=True)
 def group_by(df, *args):
+    assert_known_cols(df, args)
     df._grouped_by = list(args)
     return df
 

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -11,3 +11,6 @@ def test_group_attributes():
     d = diamonds >> group_by('cut')
     assert hasattr(d, '_grouped_by')
     assert d._grouped_by == ['cut',]
+
+    with pytest.raises(Exception, match='unknown'):
+        diamonds >> group_by('bad_col')


### PR DESCRIPTION
One quick note: I put `assert_known_cols()` inside `group_by()` instead of within `group_delegation.__call__()` b/c I wanted the error to be thrown even if no grouped function is called on the data. In other words, I wanted there to be an error when running code like this:

```python
x = diamonds >> group_by('bad_col')
```